### PR TITLE
Issue #49: Remove gap adjustment from connector position offset

### DIFF
--- a/VWorkflows-FX/src/main/java/eu/mihosoft/vrl/workflow/fx/FXFlowNodeSkin.java
+++ b/VWorkflows-FX/src/main/java/eu/mihosoft/vrl/workflow/fx/FXFlowNodeSkin.java
@@ -500,7 +500,7 @@ public class FXFlowNodeSkin
         double startX = midPointOfNode - totalWidth / 2;
 
         double offsetX = +(connectorWidth + gap) * connectorIndex
-                + (connectorWidth + gap) / 2;
+                + connectorWidth / 2;
 
         double x = startX + offsetX;
 
@@ -545,7 +545,7 @@ public class FXFlowNodeSkin
         double y = startY;
 
         double offsetY = +(connectorHeight + gap) * connectorIndex
-                + (connectorHeight + gap) / 2;
+                + connectorHeight / 2;
 
         y += offsetY;
 


### PR DESCRIPTION
This is a quick fix which is least intrusive. In essence the adjustment by (+ connectorWidth / 2) in computeConnectorXValue is undone by several (- connectorShape.getRadius()) adjustments in other parts of the code.

As from reading the code I understand the semantic of this value is the layoutX value, these adjustments should be removed at all.
