### PR TITLE
Add a cache for NodeLookup

### DIFF
--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/FlowModelImpl.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/FlowModelImpl.java
@@ -187,6 +187,7 @@ public class FlowModelImpl implements FlowModel {
 //            ((FlowModel)n).clear();
 //        }
         VNode result = nodes.remove(n.getId());
+        nodeLookup.invalidateCache();
         observableNodes.remove(n);
 
 //        removeNodeSkin(n);

--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookup.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookup.java
@@ -48,4 +48,9 @@ public interface NodeLookup extends Lookup<VNode> {
      * such connector exists
      */
     public Connector getConnectorById(String id);
+
+    /**
+     * Invalidates the Lookup cache;
+     */
+    default void invalidateCache() {};
 }

--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
@@ -81,7 +81,6 @@ public class NodeLookupImpl implements NodeLookup {
         
         if (result == null) {
             result = getNodeByGlobalId(root, globalId);
-            cache.put(globalId, result);
         }
         return result;
     }

--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
@@ -33,6 +33,7 @@
  */
 package eu.mihosoft.vrl.workflow;
 
+import java.util.HashMap;
 import java.util.Objects;
 
 /**
@@ -46,7 +47,7 @@ import java.util.Objects;
 public class NodeLookupImpl implements NodeLookup {
 
     private final VFlowModel root;
-//    private final Map<String, VNode> cache = new HashMap<>();
+    private HashMap<String, VNode> cache = new HashMap<String, VNode>();
 
     public NodeLookupImpl(VFlowModel root) {
         this.root = root;
@@ -75,16 +76,19 @@ public class NodeLookupImpl implements NodeLookup {
 
     @Override
     public VNode getById(String globalId) {
+        VNode result = cache.get(globalId);
         
-//        VNode result = cache.get(globalId);
-        
-//        if (result!=null)return result;
-
-        VNode result = getNodeByGlobalId(root, globalId);
-        
-//        cache.put(globalId, result);
-
+        if (result == null) {
+            result = getNodeByGlobalId(root, globalId);
+            cache.put(globalId, result);
+        }
         return result;
+    }
+
+    @Override
+    public void invalidateCache() {
+        System.out.println("Cache invalidated");
+        cache.clear();
     }
 
     private VNode getNodeByGlobalId(VFlowModel parent, String id) {
@@ -97,7 +101,7 @@ public class NodeLookupImpl implements NodeLookup {
             if (n.getId().equals(id)) {
                 return n;
             }
-
+            cache.put(n.getId(), n);
             if (n instanceof FlowModel) {
                 VNode result = getNodeByGlobalId((VFlowModel) n, id);
                 if (result != null) {

--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
@@ -34,6 +34,7 @@
 package eu.mihosoft.vrl.workflow;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -47,7 +48,7 @@ import java.util.Objects;
 public class NodeLookupImpl implements NodeLookup {
 
     private final VFlowModel root;
-    private HashMap<String, VNode> cache = new HashMap<String, VNode>();
+    private final Map<String, VNode> cache = new HashMap<>();
 
     public NodeLookupImpl(VFlowModel root) {
         this.root = root;

--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
@@ -87,7 +87,6 @@ public class NodeLookupImpl implements NodeLookup {
 
     @Override
     public void invalidateCache() {
-        System.out.println("Cache invalidated");
         cache.clear();
     }
 

--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/NodeLookupImpl.java
@@ -97,10 +97,10 @@ public class NodeLookupImpl implements NodeLookup {
         }
 
         for (VNode n : parent.getNodes()) {
+            cache.put(n.getId(), n);
             if (n.getId().equals(id)) {
                 return n;
             }
-            cache.put(n.getId(), n);
             if (n instanceof FlowModel) {
                 VNode result = getNodeByGlobalId((VFlowModel) n, id);
                 if (result != null) {

--- a/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/VFlowImpl.java
+++ b/VWorkflows-Core/src/main/java/eu/mihosoft/vrl/workflow/VFlowImpl.java
@@ -472,6 +472,7 @@ class VFlowImpl implements VFlow {
 
     @Override
     public VNode remove(VNode n) {
+        getNodeLookup().invalidateCache();
         return getModel().remove(n);
     }
 


### PR DESCRIPTION
This reintroduces a previously introduced cache with an improvement
to add every node seen during lookup instead only the nodes found.

With this fix we see improvements from 30-60 % with some complex workflows.
